### PR TITLE
fix: set permissions on the CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/kalbasit/fastcdc/security/code-scanning/1](https://github.com/kalbasit/fastcdc/security/code-scanning/1)

To fix the problem, explicitly define least-privilege `GITHUB_TOKEN` permissions in the workflow. Since the job only needs to read the repository contents (for `actions/checkout`) and does not perform any repository write operations, `contents: read` at the workflow or job level is sufficient.

The best fix without changing existing functionality is:

- Add a `permissions:` block at the top (workflow) level so it applies to all jobs, with `contents: read`.
- Do not modify any steps, actions versions, or logic.

Concretely, in `.github/workflows/ci.yml`:

- Insert a `permissions:` section after the `name: CI` line and before the `on:` block:

```yaml
name: CI
permissions:
  contents: read
on:
  push:
    ...
```

No additional imports, methods, or definitions are required because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
